### PR TITLE
Improve known name matching logic and phone validation

### DIFF
--- a/src/main/java/org/immregistries/mqe/validator/engine/codes/KnowNameList.java
+++ b/src/main/java/org/immregistries/mqe/validator/engine/codes/KnowNameList.java
@@ -20,9 +20,7 @@ public enum KnowNameList {
 
 
   public List<KnownName> getNames() {
-    List<KnownName> nms = new ArrayList<KnownName>();
-    Collections.copy(nms, names);;
-    return nms;
+	return new ArrayList<KnownName>(this.names);
   }
 
   public List<KnownName> getKnownNames(NameType type) {
@@ -80,20 +78,23 @@ public enum KnowNameList {
     }
     for (KnownName name : typeNames) {
 
-      if (!StringUtils.isBlank(name.getNameLast()) && !StringUtils.isBlank(last)
-          && name.getNameLast().equalsIgnoreCase(last)) {
-        return true;
+      boolean shouldMatchFirstName = !StringUtils.isBlank(name.getNameFirst());
+      boolean shouldMatchLastName = !StringUtils.isBlank(name.getNameLast());
+      boolean shouldMatchMiddleName = !StringUtils.isBlank(name.getNameMiddle());
+
+      if(shouldMatchFirstName && !(!StringUtils.isBlank(first) && name.getNameFirst().equalsIgnoreCase(first))) {
+        continue;
       }
 
-      if (!StringUtils.isBlank(name.getNameFirst()) && !StringUtils.isBlank(first)
-          && name.getNameFirst().equalsIgnoreCase(first)) {
-        return true;
+      if(shouldMatchLastName && !(!StringUtils.isBlank(last) && name.getNameLast().equalsIgnoreCase(last))) {
+        continue;
       }
 
-      if (!StringUtils.isBlank(name.getNameMiddle()) && !StringUtils.isBlank(middle)
-          && name.getNameMiddle().equalsIgnoreCase(middle)) {
-        return true;
+      if(shouldMatchMiddleName && !(!StringUtils.isBlank(middle) && name.getNameMiddle().equalsIgnoreCase(middle))) {
+        continue;
       }
+
+      return true;
     }
     return false;
   }

--- a/src/main/java/org/immregistries/mqe/validator/engine/common/PhoneValidator.java
+++ b/src/main/java/org/immregistries/mqe/validator/engine/common/PhoneValidator.java
@@ -62,6 +62,12 @@ public enum PhoneValidator {
         }
       }
 
+    } else if(phone != null && phone.getSingleFieldinput() != null && !phone.getSingleFieldinput().isEmpty()) {
+      issues.add(Detection.get(piPhone, DetectionType.PRESENT).build(meta));
+      Detection attr = Detection.get(piPhone, DetectionType.INVALID);
+      if (attr != null) {
+        issues.add(attr.build(phone.getFormattedNumber(), meta));
+      }
     } else {
       issues.add(Detection.get(piPhone, DetectionType.MISSING).build(meta));
     }


### PR DESCRIPTION
# Known Names Match
Found an issue with Known Names Matching, the current logic considers a match if one of the last, first, middle name matches a known name, but the logic should only match if all 3 fields match (for the fields that have a value)
E.g. A current known name for test data is "DONALD" _ "DUCK", in the current logic any patient with first name "DONALD" would match this known name as test data, however we only want names that match both "DONALD" for the first name and "DUCK" for the last name.

# Phone Validation
Found an issue with phone validation, when the string provided is invalid, the phone is considered missing instead of invalid, this is due to the fact that the string is first parsed to get it's components and if the parsing fails the value of the phone is null. This PR fixes this behavior by also checking what the input value is and if an input value was provided the phone is considered invalid instead of missing.